### PR TITLE
use string formatting to avoid "Can't concat [something] to str" Error…

### DIFF
--- a/eventsourcing/infrastructure/stored_events/transcoders.py
+++ b/eventsourcing/infrastructure/stored_events/transcoders.py
@@ -201,7 +201,7 @@ def deserialize_domain_entity(entity_topic, entity_attrs):
 
 
 def make_stored_entity_id(id_prefix, entity_id):
-    return id_prefix + '::' + entity_id
+    return '%s::%s' % (id_prefix, entity_id)
 
 
 def id_prefix_from_event(domain_event):


### PR DESCRIPTION
… and will work for anything impelemts __str__, for example uuid.UUID class.