### PR TITLE
Remove hard-code dependency on default StoredEvent Implementation from AbstractStoredEventRepository

### DIFF
--- a/eventsourcing/domain/services/eventstore.py
+++ b/eventsourcing/domain/services/eventstore.py
@@ -4,7 +4,7 @@ from abc import ABCMeta, abstractmethod
 import six
 
 from eventsourcing.domain.model.events import DomainEvent
-from eventsourcing.domain.services.transcoding import AbstractTranscoder, Transcoder, StoredEvent
+from eventsourcing.domain.services.transcoding import AbstractTranscoder, Transcoder
 from eventsourcing.exceptions import ProgrammingError, EntityVersionDoesNotExist, ConcurrencyError
 from eventsourcing.utils.time import time_from_uuid
 
@@ -32,7 +32,6 @@ class AbstractEventStore(six.with_metaclass(ABCMeta)):
 
 
 class EventStore(AbstractEventStore):
-
     def __init__(self, stored_event_repo, transcoder=None):
         assert isinstance(stored_event_repo, AbstractStoredEventRepository), stored_event_repo
         if transcoder is None:
@@ -91,13 +90,14 @@ class EventStore(AbstractEventStore):
 
 
 class AbstractStoredEventRepository(six.with_metaclass(ABCMeta)):
-
-    def __init__(self, always_check_expected_version=False, always_write_entity_version=False):
+    def __init__(self, always_check_expected_version=False, always_write_entity_version=False,
+                 stored_event_class=Transcoder.StoredEvent):
         """
         Base class for a persistent collection of stored events.
         """
         self.always_check_expected_version = always_check_expected_version
         self.always_write_entity_version = always_write_entity_version
+        self.stored_event_class = stored_event_class
         if self.always_check_expected_version and not self.always_write_entity_version:
             raise ProgrammingError("If versions are checked, they must also be written.")
 
@@ -106,7 +106,7 @@ class AbstractStoredEventRepository(six.with_metaclass(ABCMeta)):
         Saves given stored event in this repository.
         """
         # Check the new event is a stored event instance.
-        assert isinstance(new_stored_event, StoredEvent)
+        assert isinstance(new_stored_event, self.stored_event_class)
 
         # Validate the expected version.
         if self.always_check_expected_version:
@@ -128,7 +128,7 @@ class AbstractStoredEventRepository(six.with_metaclass(ABCMeta)):
         Raises a concurrency error if the expected version doesn't exist,
         or if the new event occurred before the expected version occurred.
         """
-        assert isinstance(new_stored_event, StoredEvent)
+        assert isinstance(new_stored_event, self.stored_event_class)
 
         stored_entity_id = new_stored_event.stored_entity_id
         expected_version_number = self.decide_expected_version_number(new_version_number)
@@ -279,7 +279,7 @@ class StoredEventIterator(six.with_metaclass(ABCMeta)):
     def _update_position(self, stored_event):
         if stored_event is None:
             return
-        assert isinstance(stored_event, StoredEvent), type(stored_event)
+        assert isinstance(stored_event, self.repo.stored_event_class), type(stored_event)
         if self.is_ascending:
             self.after = stored_event.event_id
         else:

--- a/eventsourcing/domain/services/transcoding.py
+++ b/eventsourcing/domain/services/transcoding.py
@@ -16,10 +16,8 @@ from eventsourcing.domain.model.events import topic_from_domain_class, resolve_d
 try:
     import numpy
     from six import BytesIO
-except:
+except ImportError:
     numpy = None
-
-StoredEvent = namedtuple('StoredEvent', ['event_id', 'stored_entity_id', 'event_topic', 'event_attrs'])
 
 EntityVersion = namedtuple('EntityVersion', ['entity_version_id', 'event_id'])
 
@@ -35,9 +33,14 @@ class AbstractTranscoder(six.with_metaclass(ABCMeta)):
 
 
 class Transcoder(AbstractTranscoder):
+    """
+    default implementation of a Transcoder
+    """
 
     serialize_without_json = False
     serialize_with_uuid1 = True
+
+    StoredEvent = namedtuple('StoredEvent', ['event_id', 'stored_entity_id', 'event_topic', 'event_attrs'])
 
     def __init__(self, json_encoder_cls=None, json_decoder_cls=None, cipher=None, always_encrypt=False):
         self.json_encoder_cls = json_encoder_cls
@@ -46,111 +49,87 @@ class Transcoder(AbstractTranscoder):
         self.always_encrypt = always_encrypt
 
     def serialize(self, domain_event):
-        return serialize_domain_event(
-            domain_event,
-            json_encoder_cls=self.json_encoder_cls,
-            without_json=self.serialize_without_json,
-            with_uuid1=self.serialize_with_uuid1,
-            cipher=self.cipher,
-            always_encrypt=self.always_encrypt,
+        """
+        Serializes a domain event into a stored event.
+        """
+        # assert isinstance(domain_event, DomainEvent)
+
+        # Copy the state of the domain event.
+        event_attrs = domain_event.__dict__.copy()
+
+        # Get, or make, the domain event ID.
+        if self.serialize_with_uuid1:
+            event_id = event_attrs.pop('domain_event_id')
+        else:
+            event_id = uuid.uuid4().hex
+
+        # Make stored entity ID and topic.
+        stored_entity_id = make_stored_entity_id(id_prefix_from_event(domain_event), domain_event.entity_id)
+        event_topic = topic_from_domain_class(type(domain_event))
+
+        # Serialise event attributes to JSON, optionally encrypted with cipher.
+        if not self.serialize_without_json:
+
+            if self.json_encoder_cls is None:
+                self.json_encoder_cls = ObjectJSONEncoder
+
+            event_attrs = json.dumps(event_attrs, separators=(',', ':'), sort_keys=True, cls=self.json_encoder_cls)
+
+            if self.always_encrypt or domain_event.__class__.always_encrypt:
+                if self.cipher is None:
+                    raise ValueError("Can't encrypt without a cipher")
+                event_attrs = self.cipher.encrypt(event_attrs)
+
+        # Return a named tuple.
+        return self.StoredEvent(
+            event_id=event_id,
+            stored_entity_id=stored_entity_id,
+            event_topic=event_topic,
+            event_attrs=event_attrs,
         )
 
     def deserialize(self, stored_event):
-        return deserialize_domain_event(
-            stored_event,
-            json_decoder_cls=self.json_decoder_cls,
-            without_json=self.serialize_without_json,
-            with_uuid1=self.serialize_with_uuid1,
-            cipher=self.cipher,
-            always_encrypt=self.always_encrypt,
-        )
+        """
+        Recreates original domain event from stored event topic and event attrs.
+        """
+        assert isinstance(stored_event, self.StoredEvent)
 
+        # Get the domain event class from the topic.
+        event_class = resolve_domain_topic(stored_event.event_topic)
 
-def serialize_domain_event(domain_event, json_encoder_cls=None, without_json=False, with_uuid1=False, cipher=None,
-                           always_encrypt=False):
-    """
-    Serializes a domain event into a stored event.
-    """
-    # assert isinstance(domain_event, DomainEvent)
+        if not isinstance(event_class, type):
+            raise ValueError("Event class is not a type: {}".format(event_class))
 
-    # Copy the state of the domain event.
-    event_attrs = domain_event.__dict__.copy()
+        if not issubclass(event_class, DomainEvent):
+            raise ValueError("Event class is not a DomainEvent: {}".format(event_class))
 
-    # Get, or make, the domain event ID.
-    if with_uuid1:
-        event_id = event_attrs.pop('domain_event_id')
-    else:
-        event_id = uuid.uuid4().hex
+        # Deserialize event attributes from JSON, optionally decrypted with cipher.
+        event_attrs = stored_event.event_attrs
+        if not self.serialize_without_json:
 
-    # Make stored entity ID and topic.
-    stored_entity_id = make_stored_entity_id(id_prefix_from_event(domain_event), domain_event.entity_id)
-    event_topic = topic_from_domain_class(type(domain_event))
+            if self.json_decoder_cls is None:
+                self.json_decoder_cls = ObjectJSONDecoder
 
-    # Serialise event attributes to JSON, optionally encrypted with cipher.
-    if not without_json:
+            if self.always_encrypt or event_class.always_encrypt:
+                if self.cipher is None:
+                    raise ValueError("Can't decrypt stored event without a cipher")
+                event_attrs = self.cipher.decrypt(event_attrs)
 
-        if json_encoder_cls is None:
-            json_encoder_cls = ObjectJSONEncoder
+            event_attrs = json.loads(event_attrs, cls=self.json_decoder_cls)
 
-        event_attrs = json.dumps(event_attrs, separators=(',', ':'), sort_keys=True, cls=json_encoder_cls)
+        # Set the domain event ID.
+        if self.serialize_with_uuid1:
+            event_attrs['domain_event_id'] = stored_event.event_id
 
-        if always_encrypt or domain_event.__class__.always_encrypt:
-            if cipher is None:
-                raise ValueError("Can't encrypt without a cipher")
-            event_attrs = cipher.encrypt(event_attrs)
+        # Reinstantiate and return the domain event object.
+        try:
+            domain_event = object.__new__(event_class)
+            domain_event.__dict__.update(event_attrs)
+        except TypeError:
+            raise ValueError("Unable to instantiate class '{}' with data '{}'"
+                             "".format(stored_event.event_topic, event_attrs))
 
-    # Return a named tuple.
-    return StoredEvent(
-        event_id=event_id,
-        stored_entity_id=stored_entity_id,
-        event_topic=event_topic,
-        event_attrs=event_attrs,
-    )
-
-
-def deserialize_domain_event(stored_event, json_decoder_cls=None, without_json=False, with_uuid1=False, cipher=None,
-                             always_encrypt=False):
-    """
-    Recreates original domain event from stored event topic and event attrs.
-    """
-    assert isinstance(stored_event, StoredEvent)
-
-    # Get the domain event class from the topic.
-    event_class = resolve_domain_topic(stored_event.event_topic)
-
-    if not isinstance(event_class, type):
-        raise ValueError("Event class is not a type: {}".format(event_class))
-
-    if not issubclass(event_class, DomainEvent):
-        raise ValueError("Event class is not a DomainEvent: {}".format(event_class))
-
-    # Deserialize event attributes from JSON, optionally decrypted with cipher.
-    event_attrs = stored_event.event_attrs
-    if not without_json:
-
-        if json_decoder_cls is None:
-            json_decoder_cls = ObjectJSONDecoder
-
-        if always_encrypt or event_class.always_encrypt:
-            if cipher is None:
-                raise ValueError("Can't decrypt stored event without a cipher")
-            event_attrs = cipher.decrypt(event_attrs)
-
-        event_attrs = json.loads(event_attrs, cls=json_decoder_cls)
-
-    # Set the domain event ID.
-    if with_uuid1:
-        event_attrs['domain_event_id'] = stored_event.event_id
-
-    # Reinstantiate and return the domain event object.
-    try:
-        domain_event = object.__new__(event_class)
-        domain_event.__dict__.update(event_attrs)
-    except TypeError:
-        raise ValueError("Unable to instantiate class '{}' with data '{}'"
-                         "".format(stored_event.event_topic, event_attrs))
-
-    return domain_event
+        return domain_event
 
 
 class ObjectJSONEncoder(json.JSONEncoder):

--- a/eventsourcing/tests/test_stored_events.py
+++ b/eventsourcing/tests/test_stored_events.py
@@ -5,20 +5,22 @@ from six import with_metaclass
 
 from eventsourcing.domain.model.events import DomainEvent, topic_from_domain_class, QualnameABCMeta
 from eventsourcing.domain.model.example import Example
-from eventsourcing.domain.services.transcoding import serialize_domain_event, deserialize_domain_event, \
-    resolve_domain_topic, StoredEvent, ObjectJSONDecoder, ObjectJSONEncoder
+from eventsourcing.domain.services.transcoding import Transcoder, resolve_domain_topic, ObjectJSONDecoder, ObjectJSONEncoder
 from eventsourcing.exceptions import TopicResolutionError
 from eventsourcing.utils.time import utc_timezone
 
 
 class TestStoredEvent(TestCase):
+    def setUp(self):
+        self.transcoder = Transcoder(json_encoder_cls=ObjectJSONEncoder, json_decoder_cls=ObjectJSONDecoder)
+        self.transcoder.serialize_with_uuid1 = False
 
     def test_serialize_domain_event(self):
         datetime_now = datetime.datetime(2015, 9, 8, 16, 20, 50, 577429)
         datetime_now_tzaware = datetime.datetime(2015, 9, 8, 16, 20, 50, 577429, tzinfo=utc_timezone)
         date_now = datetime.date(2015, 9, 8)
         event1 = DomainEvent(a=1, b=2, c=datetime_now, d=datetime_now_tzaware, e=date_now, entity_version=0, entity_id='entity1', domain_event_id=3)
-        stored_event = serialize_domain_event(event1, json_encoder_cls=ObjectJSONEncoder)
+        stored_event = self.transcoder.serialize(event1)
         self.assertEqual('DomainEvent::entity1', stored_event.stored_entity_id)
         self.assertEqual('eventsourcing.domain.model.events#DomainEvent', stored_event.event_topic)
         self.assertEqual('{"a":1,"b":2,"c":{"ISO8601_datetime":"2015-09-08T16:20:50.577429"},"d":{"ISO8601_datetime":"2015-09-08T16:20:50.577429+0000"},"domain_event_id":3,"e":{"ISO8601_date":"2015-09-08"},"entity_id":"entity1","entity_version":0}',
@@ -33,7 +35,7 @@ class TestStoredEvent(TestCase):
         if numpy is not None:
             event1 = DomainEvent(a=numpy.array([10.123456]), entity_version=0, entity_id='entity1', domain_event_id=3)
 
-            stored_event = serialize_domain_event(event1, json_encoder_cls=ObjectJSONEncoder)
+            stored_event = self.transcoder.serialize(event1)
             self.assertEqual('eventsourcing.domain.model.events#DomainEvent', stored_event.event_topic)
             self.assertEqual('{"a":{"__ndarray__":"\\"\\\\u0093NUMPY\\\\u0001\\\\u0000F\\\\u0000{\'descr\': \'<f8\', \'fortran_order\': False, \'shape\': (1,), }            \\\\nm\\\\u00fd\\\\u00f4\\\\u009f5?$@\\""},"domain_event_id":3,"entity_id":"entity1","entity_version":0}',
                              stored_event.event_attrs)
@@ -41,11 +43,11 @@ class TestStoredEvent(TestCase):
             self.skipTest("Skipped test because numpy is not installed")
 
     def test_recreate_domain_event(self):
-        stored_event = StoredEvent(event_id='1',
+        stored_event = Transcoder.StoredEvent(event_id='1',
                                    stored_entity_id='entity1',
                                    event_topic='eventsourcing.domain.model.events#DomainEvent',
                                    event_attrs='{"a":1,"b":2,"c":{"ISO8601_datetime":"2015-09-08T16:20:50.577429"},"d":{"ISO8601_datetime":"2015-09-08T16:20:50.577429+0000"},"domain_event_id":3,"e":{"ISO8601_date":"2015-09-08"},"entity_id":"entity1","entity_version":0}')
-        domain_event = deserialize_domain_event(stored_event, json_decoder_cls=ObjectJSONDecoder)
+        domain_event = self.transcoder.deserialize(stored_event)
         self.assertIsInstance(domain_event, DomainEvent)
         self.assertEqual('entity1', domain_event.entity_id)
         self.assertEqual(1, domain_event.a)
@@ -58,11 +60,11 @@ class TestStoredEvent(TestCase):
         self.assertEqual(3, domain_event.domain_event_id)
 
         # Check the TypeError is raised.
-        stored_event = StoredEvent(event_id='1',
+        stored_event = Transcoder.StoredEvent(event_id='1',
                                    stored_entity_id='entity1',
                                    event_topic=topic_from_domain_class(NotADomainEvent),
                                    event_attrs='{"a":1,"b":2,"stored_entity_id":"entity1","timestamp":3}')
-        self.assertRaises(ValueError, deserialize_domain_event, stored_event, json_decoder_cls=ObjectJSONDecoder)
+        self.assertRaises(ValueError, self.transcoder.deserialize, stored_event)
 
     def test_resolve_event_topic(self):
         example_topic = 'eventsourcing.domain.model.example#Example.Created'

--- a/eventsourcing/tests/unit_test_cases.py
+++ b/eventsourcing/tests/unit_test_cases.py
@@ -12,7 +12,7 @@ from uuid import uuid4, uuid1
 import six
 
 from eventsourcing.domain.services.eventstore import AbstractStoredEventRepository, SimpleStoredEventIterator
-from eventsourcing.domain.services.transcoding import StoredEvent
+from eventsourcing.domain.services.transcoding import Transcoder
 from eventsourcing.exceptions import ConcurrencyError
 from eventsourcing.infrastructure.stored_event_repos.with_cassandra import CassandraStoredEventRepository, \
     setup_cassandra_connection, get_cassandra_setup_params
@@ -20,6 +20,8 @@ from eventsourcing.infrastructure.stored_event_repos.with_python_objects import 
 from eventsourcing.infrastructure.stored_event_repos.with_sqlalchemy import SQLAlchemyStoredEventRepository, \
     get_scoped_session_facade
 from eventsourcing.infrastructure.stored_event_repos.threaded_iterator import ThreadedStoredEventIterator
+
+StoredEvent = Transcoder.StoredEvent
 
 
 class AbstractTestCase(TestCase):


### PR DESCRIPTION
1. remove hard-code dependency on default StoredEvent Implementation(schema) from AbstractStoredEventRepository. Since it's a Abstract repo, it should be able to handle different types of stored event.

2. moved StoredEvent into Transcoder Implementation since only Transcoder uses it and should depend on it

3. refactored default transcoder implementation by merging (de)serialize implementations into it since they are only needed there