### PR TITLE
Add sequenced_item_mapper_class parameter in construct_infrastructure argument forwarding

### DIFF
--- a/eventsourcing/application/simple.py
+++ b/eventsourcing/application/simple.py
@@ -123,6 +123,7 @@ class SimpleApplication(ABC):
             record_manager_class=self.record_manager_class,
             integer_sequenced_record_class=self.stored_event_record_class,
             sequenced_item_class=self.sequenced_item_class,
+            sequenced_item_mapper_class=self.sequenced_item_mapper_class,
             contiguous_record_ids=self.contiguous_record_ids,
             application_name=self.name,
             pipeline_id=self.pipeline_id,


### PR DESCRIPTION
You can create any application like SQLAlchemyApplication and others and pass custom sequenced_item_mapper_class as argument, but it affects nothing because default SequencedItemMapper instance will be created anyway
Also it requires unit tes like core_tests/test_sequenced_item_mapper.py but I have no possibility to check tests because of issue https://github.com/johnbywater/eventsourcing/issues/175