### PR TITLE
Removing trailing semicolon in sql query (Oracle problem)

### DIFF
--- a/eventsourcing/infrastructure/base.py
+++ b/eventsourcing/infrastructure/base.py
@@ -515,7 +515,7 @@ class SQLRecordManager(RecordManagerWithTracking):
         return self._insert_tracking_record
 
     _insert_values_tmpl = (
-        "INSERT INTO {tablename} ({columns}) " "VALUES ({placeholders});"
+        "INSERT INTO {tablename} ({columns}) " "VALUES ({placeholders})"
     )
 
     @abstractmethod


### PR DESCRIPTION
Hello,

We are trying to use this library with an Oracle database and we have had to change the insert query template removing the trailing comma because we were getting this error:
(cx_Oracle.DatabaseError) ORA-00911: invalid character

Thanks for this awesome library!

Best regards,
-Jose.
