### PR TITLE
Support for alias in Django record manager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ before_install:
 before_script:
   - mysql -e 'CREATE DATABASE eventsourcing;'
   - psql -c 'CREATE DATABASE eventsourcing;' -U postgres
+  - psql -c 'CREATE DATABASE eventsourcing_secondary;' -U postgres
 
 install:
   - pip install -U virtualenv

--- a/eventsourcing/infrastructure/django/factory.py
+++ b/eventsourcing/infrastructure/django/factory.py
@@ -12,12 +12,14 @@ class DjangoInfrastructureFactory(InfrastructureFactory):
 
     record_manager_class = DjangoRecordManager
     tracking_record_class: Any = None
+    db_alias: str = None
 
     def __init__(
-        self, tracking_record_class: Optional[type] = None, *args: Any, **kwargs: Any
+        self, db_alias: str, tracking_record_class: Optional[type] = None, *args: Any, **kwargs: Any
     ):
         super(DjangoInfrastructureFactory, self).__init__(*args, **kwargs)
         self._tracking_record_class = tracking_record_class
+        self.db_alias = db_alias
 
     @property
     def integer_sequenced_record_class(self) -> Optional[type]:  # type: ignore
@@ -52,5 +54,7 @@ class DjangoInfrastructureFactory(InfrastructureFactory):
         return super(
             DjangoInfrastructureFactory, self
         ).construct_integer_sequenced_record_manager(
-            tracking_record_class=tracking_record_class, **kwargs
+            tracking_record_class=tracking_record_class,
+            db_alias=self.db_alias,
+            **kwargs
         )

--- a/eventsourcing/tests/djangoproject/djangoproject/settings.py
+++ b/eventsourcing/tests/djangoproject/djangoproject/settings.py
@@ -95,6 +95,13 @@ DATABASES = {
         "NAME": "eventsourcing",
         "USER": os.getenv("POSTGRES_USER", "eventsourcing"),
         "PASSWORD": os.getenv("POSTGRES_PASSWORD", "eventsourcing"),
+    },
+    "secondary": {
+        "ENGINE": "django.db.backends.postgresql_psycopg2",
+        "HOST": os.getenv("POSTGRES_HOST", "127.0.0.1"),
+        "NAME": "eventsourcing_secondary",
+        "USER": os.getenv("POSTGRES_USER", "eventsourcing"),
+        "PASSWORD": os.getenv("POSTGRES_PASSWORD", "eventsourcing"),
     }
 }
 

--- a/eventsourcing/tests/test_system_with_django.py
+++ b/eventsourcing/tests/test_system_with_django.py
@@ -1,3 +1,7 @@
+from time import sleep
+
+from django.core.management import call_command
+
 from eventsourcing.application.django import DjangoApplication
 from eventsourcing.tests.sequenced_item_tests.test_django_record_manager import (
     DjangoTestCase,
@@ -14,6 +18,22 @@ class TestSystemWithDjango(DjangoTestCase, TestSystem):
     def set_db_uri(self):
         # The Django settings module doesn't currently recognise DB_URI.
         pass
+
+
+class SecondaryDjangoApplication(DjangoApplication):
+
+    def construct_infrastructure(self):
+        super(SecondaryDjangoApplication, self).construct_infrastructure(db_alias='secondary')
+
+
+class TestSystemWithSecondaryDBDjango(DjangoTestCase, TestSystem):
+    infrastructure_class = SecondaryDjangoApplication
+    databases = ["secondary", "default"]
+
+    def setUp(self):
+        super(DjangoTestCase, self).setUp()
+        call_command("migrate", database="secondary", verbosity=0, interactive=False)
+        sleep(1)
 
 
 # Avoid running imported test case.


### PR DESCRIPTION
Adds support for db alias in record manager. 
Useful in case of multiple django applications in the same codebase. 
Other usecase is migration of the eventstore using different alias

This is just a POC. Additional changes may be needed.